### PR TITLE
Complete rewrite, regions, and shop items support

### DIFF
--- a/worlds/noita/Events.py
+++ b/worlds/noita/Events.py
@@ -1,4 +1,4 @@
-from BaseClasses import Item, MultiWorld, Region, Location
+from BaseClasses import Item, MultiWorld, Region, Location, ItemClassification
 from . import Items, Locations
 
 

--- a/worlds/noita/Events.py
+++ b/worlds/noita/Events.py
@@ -1,0 +1,43 @@
+from BaseClasses import Item, MultiWorld, Region, Location
+from . import Items, Locations
+
+
+def create_event(player: int, name: str) -> Item:
+    return Items.NoitaItem(name, ItemClassification.progression, None, player)
+
+
+def create_location(player: int, name: str, region: Region) -> Location:
+    return Locations.NoitaLocation(player, name, None, region)
+
+
+def create_victory_events(world: MultiWorld, player: int) -> None:
+    # Generate Victory shenanigans (TODO this is temporary)
+    the_work_region = world.get_region("The Work", player)
+    victory_loc = create_location(player, "Victory", the_work_region)
+
+    victory_loc.place_locked_item(create_event(player, "Victory"))
+    world.completion_condition[player] = lambda state: state.has("Victory", player)
+
+    the_work_region.locations.append(victory_loc)
+
+
+def create_chest_events(world: MultiWorld, player: int) -> None:
+    total_locations = world.total_locations[player].value
+
+    # TODO This is a hack for now, we throw all the chest popups in Forest
+    forest_region = world.get_region("Forest", player)
+
+    # Iterates all our generated chests and makes sure that they are accessible in a specific
+    # logical order (?) TODO: Revisit and confirm this
+    for i in range(1, 1 + total_locations):
+        pickup_event = create_event(player, f"Pickup{(i + 1)}")
+
+        event_loc = create_location(player, pickup_event.name, forest_region)
+        event_loc.place_locked_item(pickup_event)
+        event_loc.access_rule(lambda state, i=i: state.can_reach(f"Chest{i}", "Location", player))
+        forest_region.locations.append(event_loc)
+
+
+def create_all_events(world: MultiWorld, player: int) -> None:
+    create_victory_events(world, player)
+    create_chest_events(world, player)

--- a/worlds/noita/Events.py
+++ b/worlds/noita/Events.py
@@ -33,7 +33,7 @@ def create_chest_events(world: MultiWorld, player: int) -> None:
     # logical order (?) TODO: Revisit and confirm this
     for i in range(1, 1 + total_locations):
         event_loc = create_locked_location_event(world, player, "Forest", f"Pickup{(i + 1)}")
-        event_loc.access_rule(lambda state, i=i: state.can_reach(f"Chest{i}", "Location", player))
+        event_loc.access_rule = lambda state, i=i: state.can_reach(f"Chest{i}", "Location", player)
 
 
 def create_all_events(world: MultiWorld, player: int) -> None:

--- a/worlds/noita/Events.py
+++ b/worlds/noita/Events.py
@@ -10,32 +10,30 @@ def create_location(player: int, name: str, region: Region) -> Location:
     return Locations.NoitaLocation(player, name, None, region)
 
 
+def create_locked_location_event(world: MultiWorld, player: int, region_name: str, event_name: str) -> Location:
+    region = world.get_region(region_name, player)
+
+    new_location = create_location(player, event_name, region)
+    new_location.place_locked_item(create_event(player, event_name))
+
+    region.locations.append(new_location)
+    return new_location
+
+
 def create_victory_events(world: MultiWorld, player: int) -> None:
     # Generate Victory shenanigans (TODO this is temporary)
-    the_work_region = world.get_region("The Work", player)
-    victory_loc = create_location(player, "Victory", the_work_region)
-
-    victory_loc.place_locked_item(create_event(player, "Victory"))
+    create_locked_location_event(world, player, "The Work", "Victory")
     world.completion_condition[player] = lambda state: state.has("Victory", player)
-
-    the_work_region.locations.append(victory_loc)
 
 
 def create_chest_events(world: MultiWorld, player: int) -> None:
     total_locations = world.total_locations[player].value
 
-    # TODO This is a hack for now, we throw all the chest popups in Forest
-    forest_region = world.get_region("Forest", player)
-
     # Iterates all our generated chests and makes sure that they are accessible in a specific
     # logical order (?) TODO: Revisit and confirm this
     for i in range(1, 1 + total_locations):
-        pickup_event = create_event(player, f"Pickup{(i + 1)}")
-
-        event_loc = create_location(player, pickup_event.name, forest_region)
-        event_loc.place_locked_item(pickup_event)
+        event_loc = create_locked_location_event(world, player, "Forest", f"Pickup{(i + 1)}")
         event_loc.access_rule(lambda state, i=i: state.can_reach(f"Chest{i}", "Location", player))
-        forest_region.locations.append(event_loc)
 
 
 def create_all_events(world: MultiWorld, player: int) -> None:

--- a/worlds/noita/Items.py
+++ b/worlds/noita/Items.py
@@ -23,15 +23,18 @@ def create_all_items(world: MultiWorld, player: int) -> None:
     pool_option = world.bad_effects[player].value
     total_locations = world.total_locations[player].value
 
-    # Generate item pool
+    # Generate fixed item pool
     itempool: List = []
     for item_name, count in required_items.items():
         itempool += [item_name] * count
 
-    # Add other junk to the pool
+    # Add non-fixed junk to the pool to meet quota
     junk_pool = item_pool_weights[pool_option]
-    for i in range(1, total_locations + 1):
-        itempool += world.random.choices(list(junk_pool.keys()), weights=list(junk_pool.values()))
+    itempool += world.random.choices(
+        population=list(junk_pool.keys()),
+        weights=list(junk_pool.values()),
+        k=total_locations - len(itempool)
+    )
 
     # Convert itempool into real items
     world.itempool += [create_item(player, name) for name in itempool]

--- a/worlds/noita/Items.py
+++ b/worlds/noita/Items.py
@@ -1,6 +1,7 @@
 import itertools
 from typing import Dict, NamedTuple, Optional, List, Set
-from BaseClasses import Item, ItemClassification
+from BaseClasses import Item, ItemClassification, MultiWorld
+
 
 class ItemData(NamedTuple):
     code: Optional[int]
@@ -18,7 +19,7 @@ def create_item(player: int, name: str) -> Item:
     return NoitaItem(name, item_data.classification, item_data.code, player)
 
 
-def create_all_items(world, player: int) -> None:
+def create_all_items(world: MultiWorld, player: int) -> None:
     pool_option = world.bad_effects[player].value
     total_locations = world.total_locations[player].value
 
@@ -63,7 +64,6 @@ item_table: Dict[str, ItemData] = {
 }
 
 
-
 default_weights: Dict[str, int] = {
     "Wand (Tier 1)":    10,
     "Potion":           35,
@@ -106,12 +106,20 @@ item_pool_weights: Dict[int, Dict[str, int]] = {
 def get_item_group(item_name: str) -> str:
     return item_table[item_name].group
 
+
 def item_is_filler(item_name: str) -> bool:
     return item_table[item_name].classification == ItemClassification.filler
 
 
-filler_items = filter(item_is_filler, item_table.keys())
-item_name_to_id = { name: data.code for name, data in item_table.items() }
-item_name_groups = { group: set(item_names) for group, item_names in itertools.groupby(item_table, get_item_group) }
+filler_items: List[str] = list(filter(item_is_filler, item_table.keys()))
+item_name_to_id: Dict[str, int] = {name: data.code for name, data in item_table.items()}
 
-required_items = { name: data.required_num for name, data in item_table.items() }
+item_name_groups: Dict[set, Set[str]] = {
+    group: set(item_names)
+    for group, item_names in itertools.groupby(item_table, get_item_group)
+}
+
+required_items: Dict[str, int] = {
+    name: data.required_num
+    for name, data in item_table.items() if data.required_num > 0
+}

--- a/worlds/noita/Locations.py
+++ b/worlds/noita/Locations.py
@@ -1,3 +1,5 @@
+# Locations are specific points that you would obtain an item at.
+import functools
 from typing import Dict
 from BaseClasses import Location
 from .Options import TotalLocations
@@ -7,7 +9,63 @@ class NoitaLocation(Location):
     game: str = "Noita"
 
 
-# 110000 - 110500
-item_pickups: Dict[str, int] = {
-    f"Chest{i+1}": 110000+i for i in range(TotalLocations.range_end)
+# 111000 - 111034
+# Mapping of items in each region
+location_region_mapping: Dict[str, Dict[str, int]] = {
+    "Forest": {
+        # 110000 - 110500
+        # Just putting these here for now
+        f"Chest{i+1}": 110000+i for i in range(TotalLocations.range_end)
+    },
+    "Holy Mountain 1 (To Coal Pits)": {
+        "Holy Mountain 1 (To Coal Pits) Shop Item 1": 111000,
+        "Holy Mountain 1 (To Coal Pits) Shop Item 2": 111001,
+        "Holy Mountain 1 (To Coal Pits) Shop Item 3": 111002,
+        "Holy Mountain 1 (To Coal Pits) Shop Item 4": 111003,
+        "Holy Mountain 1 (To Coal Pits) Shop Item 5": 111004,
+    },
+    "Holy Mountain 2 (To Snowy Depths)": {
+        "Holy Mountain 2 (To Snowy Depths) Shop Item 1": 111005,
+        "Holy Mountain 2 (To Snowy Depths) Shop Item 2": 111006,
+        "Holy Mountain 2 (To Snowy Depths) Shop Item 3": 111007,
+        "Holy Mountain 2 (To Snowy Depths) Shop Item 4": 111008,
+        "Holy Mountain 2 (To Snowy Depths) Shop Item 5": 111009,
+    },
+    "Holy Mountain 3 (To Hiisi Base)": {
+        "Holy Mountain 3 (To Hiisi Base) Shop Item 1": 111010,
+        "Holy Mountain 3 (To Hiisi Base) Shop Item 2": 111011,
+        "Holy Mountain 3 (To Hiisi Base) Shop Item 3": 111012,
+        "Holy Mountain 3 (To Hiisi Base) Shop Item 4": 111013,
+        "Holy Mountain 3 (To Hiisi Base) Shop Item 5": 111014,
+    },
+    "Holy Mountain 4 (To Underground Jungle)": {
+        "Holy Mountain 4 (To Underground Jungle) Shop Item 1": 111015,
+        "Holy Mountain 4 (To Underground Jungle) Shop Item 2": 111016,
+        "Holy Mountain 4 (To Underground Jungle) Shop Item 3": 111017,
+        "Holy Mountain 4 (To Underground Jungle) Shop Item 4": 111018,
+        "Holy Mountain 4 (To Underground Jungle) Shop Item 5": 111019,
+    },
+    "Holy Mountain 5 (To The Vault)": {
+        "Holy Mountain 5 (To The Vault) Shop Item 1": 111020,
+        "Holy Mountain 5 (To The Vault) Shop Item 2": 111021,
+        "Holy Mountain 5 (To The Vault) Shop Item 3": 111022,
+        "Holy Mountain 5 (To The Vault) Shop Item 4": 111023,
+        "Holy Mountain 5 (To The Vault) Shop Item 5": 111024,
+    },
+    "Holy Mountain 6 (To Temple of the Art)": {
+        "Holy Mountain 6 (To Temple of the Art) Shop Item 1": 111025,
+        "Holy Mountain 6 (To Temple of the Art) Shop Item 2": 111026,
+        "Holy Mountain 6 (To Temple of the Art) Shop Item 3": 111027,
+        "Holy Mountain 6 (To Temple of the Art) Shop Item 4": 111028,
+        "Holy Mountain 6 (To Temple of the Art) Shop Item 5": 111029,
+    },
+    "Holy Mountain 7 (To The Laboratory)": {
+        "Holy Mountain 7 (To The Laboratory) Shop Item 1": 111030,
+        "Holy Mountain 7 (To The Laboratory) Shop Item 2": 111031,
+        "Holy Mountain 7 (To The Laboratory) Shop Item 3": 111032,
+        "Holy Mountain 7 (To The Laboratory) Shop Item 4": 111033,
+        "Holy Mountain 7 (To The Laboratory) Shop Item 5": 111034,
+    }
 }
+
+location_name_to_id = functools.reduce(Dict.update, location_region_mapping.values(), {})

--- a/worlds/noita/Locations.py
+++ b/worlds/noita/Locations.py
@@ -68,6 +68,6 @@ location_region_mapping: Dict[str, Dict[str, int]] = {
     }
 }
 
-location_name_to_id = {}
+location_name_to_id: Dict[str, int] = {}
 for location_group in location_region_mapping.values():
     location_name_to_id.update(location_group)

--- a/worlds/noita/Locations.py
+++ b/worlds/noita/Locations.py
@@ -68,4 +68,6 @@ location_region_mapping: Dict[str, Dict[str, int]] = {
     }
 }
 
-location_name_to_id = functools.reduce(Dict.update, location_region_mapping.values(), {})
+location_name_to_id = {}
+for location_group in location_region_mapping.values():
+    location_name_to_id.update(location_group)

--- a/worlds/noita/Options.py
+++ b/worlds/noita/Options.py
@@ -1,6 +1,7 @@
 from typing import Dict
 from Options import Option, DeathLink, DefaultOnToggle, Range
 
+
 class TotalLocations(Range):
     """Number of location checks which are added to the playthrough."""
     display_name = "Total Locations"
@@ -8,9 +9,11 @@ class TotalLocations(Range):
     range_end = 500
     default = 100
 
+
 class BadEffects(DefaultOnToggle):
     """Negative effects on the Noita world are added to the item pool."""
     display_name = "Bad Times"
+
 
 noita_options: Dict[str, type(Option)] = {
     "total_locations":      TotalLocations,

--- a/worlds/noita/Regions.py
+++ b/worlds/noita/Regions.py
@@ -91,4 +91,4 @@ noita_connections: Dict[str, Set[str]] = {
     "The Laboratory": {"Holy Mountain 7 (To The Laboratory)", "The Work"},
 }
 
-noita_regions: Set[str] = set(noita_connections.keys()) + set.union(*noita_connections.values())
+noita_regions: Set[str] = set(noita_connections.keys()).union(*noita_connections.values())

--- a/worlds/noita/Regions.py
+++ b/worlds/noita/Regions.py
@@ -1,0 +1,112 @@
+# Regions are areas in your game that you travel to.
+import itertools
+from Typing import Dict, List
+from BaseClasses import Region, Entrance, LocationProgressType
+
+
+# Creates a new Region with the locations found in `location_region_mapping`
+# and adds them to the world.
+def create_region(world, player: int, region_name: str):
+  new_region = Region(region_name, RegionType.Generic, region_name, player, world)
+
+  # Here we create and assign locations to the region
+  for location_name, location_id in Locations.location_region_mapping.get(region_name, {}).items():
+    location = Locations.NoitaLocation(player, location_name, location_id, new_region)
+
+    # If it's not the region with all the shitty chests, increases the priority of important items.
+    # This way people know they can find their items by checking fixed locations instead of
+    # leaving it up to chance.
+    if region_name != "Forest": 
+      location.progress_type = LocationProgressType.PRIORITY
+
+    new_region.locations.append(location)
+
+  world.regions.append(new_region)
+  return new_region
+
+
+# Creates connections based on our access mapping in `noita_connections`.
+def create_connections(player, regions):
+  for source, destinations in noita_connections.items():
+    new_entrances = []
+
+    for destination in destinations:
+      # An "Entrance" is really just a connection between two regions
+      entrance = Entrance(player, f"From {source} To {destination}", regions[source])
+      entrance.connect(regions[destination])
+      new_entrances.append(entrance)
+
+    created_regions[source].exits = new_entrances
+
+
+# Creates all regions and connections. Called from NoitaWorld.
+def create_all_regions(world, player: int):
+  created_regions = { name: create_region(world, player, name) for name in noita_regions }
+  create_connections(player, created_regions)
+
+
+noita_regions = {
+  "Menu", "Forest",
+  
+  "Mines", "Collapsed Mines", "Lava Lake", "Dark Cave", "Shaft",
+
+  "Coal Pits", "Fungal Caverns",
+
+  "Snowy Depths",
+
+  "Hiisi Base", "Secret Shop",
+
+  "Underground Jungle", "Dragoncave",
+
+  "The Vault",
+
+  "Temple of the Art",
+
+  "The Laboratory", "The Work",
+
+  "Holy Mountain 1 (To Coal Pits)",
+  "Holy Mountain 2 (To Snowy Depths)",
+  "Holy Mountain 3 (To Hiisi Base)",
+  "Holy Mountain 4 (To Underground Jungle)",
+  "Holy Mountain 5 (To The Vault)",
+}
+
+noita_connections: Dict[str, List[str]] = {
+  "Menu": ["Forest"],
+  "Forest": ["Mines", "Collapsed Mines"],
+
+  "Mines": ["Collapsed Mines", "Holy Mountain 1 (To Coal Pits)", "Lava Lake", "Forest"],
+  "Collapsed Mines": ["Mines", "Holy Mountain 1 (To Coal Pits)", "Dark Cave"],
+  "Lava Lake": ["Mines", "Shaft"],
+  "Shaft": ["Lava Lake", "Snowy Depths"],
+
+  ###
+  "Holy Mountain 1 (To Coal Pits)": ["Coal Pits"],
+  "Coal Pits": ["Holy Mountain 1 (To Coal Pits)", "Fungal Caverns", "Holy Mountain 2 (To Snowy Depths)"],
+  "Fungal Caverns": ["Coal Pits"],
+
+  ###
+  "Holy Mountain 2 (To Snowy Depths)": ["Snowy Depths"],
+  "Snowy Depths": ["Shaft", "Holy Mountain 2 (To Snowy Depths)", "Holy Mountain 3 (To Hiisi Base)"],
+  
+  ###
+  "Holy Mountain 3 (To Hiisi Base)": ["Hiisi Base"],
+  "Hiisi Base": ["Holy Mountain 3 (To Hiisi Base)", "Secret Shop", "Holy Mountain 4 (To Underground Jungle)"],
+
+  ###
+  "Holy Mountain 4 (To Underground Jungle)": ["Underground Jungle"],
+  "Dragoncave": ["Underground Jungle"],
+  "Underground Jungle": ["Holy Mountain 4 (To Underground Jungle)", "Dragoncave", "Holy Mountain 5 (To The Vault)"],
+  
+  ###
+  "Holy Mountain 5 (To The Vault)": ["The Vault"],
+  "The Vault": ["Holy Mountain 5 (To The Vault)", "Holy Mountain 6 (To Temple of the Art)"],
+  
+  ###
+  "Holy Mountain 6 (To Temple of the Art)": ["Temple of the Art"],
+  "Temple of the Art": ["Holy Mountain 6 (To Temple of the Art)", "Holy Mountain 7 (To The Laboratory)"],
+
+  ###
+  "Holy Mountain 7 (To The Laboratory)": ["The Laboratory"],
+  "The Laboratory": ["Holy Mountain 7 (To The Laboratory)", "The Work"],
+}

--- a/worlds/noita/Regions.py
+++ b/worlds/noita/Regions.py
@@ -1,118 +1,94 @@
 # Regions are areas in your game that you travel to.
 import itertools
-from typing import Dict, List
-from BaseClasses import Region, Entrance, LocationProgressType, RegionType
+from typing import Dict, List, Set
+from BaseClasses import Region, Entrance, LocationProgressType, RegionType, MultiWorld
 from . import Locations
 
 
 # Creates a new Region with the locations found in `location_region_mapping`
 # and adds them to the world.
-def create_region(world, player: int, region_name: str):
-  new_region = Region(region_name, RegionType.Generic, region_name, player, world)
+def create_region(world: MultiWorld, player: int, region_name: str) -> Region:
+    new_region = Region(region_name, RegionType.Generic, region_name, player, world)
 
-  # Here we create and assign locations to the region
-  for location_name, location_id in Locations.location_region_mapping.get(region_name, {}).items():
-    location = Locations.NoitaLocation(player, location_name, location_id, new_region)
+    # Here we create and assign locations to the region
+    for location_name, location_id in Locations.location_region_mapping.get(region_name, {}).items():
+        location = Locations.NoitaLocation(player, location_name, location_id, new_region)
 
-    # TODO this is a hack.
-    # If it's not the region with all the shitty chests, increases the priority of important items.
-    # This way people know they can find their items by checking fixed locations instead of
-    # leaving it up to chance.
-    if region_name != "Forest": 
-      location.progress_type = LocationProgressType.PRIORITY
+        # TODO this is a hack.
+        # If it's not the region with all the shitty chests, increases the priority of important items.
+        # This way people know they can find their items by checking fixed locations instead of leaving it up to chance.
+        if region_name != "Forest":
+            location.progress_type = LocationProgressType.PRIORITY
 
-    new_region.locations.append(location)
+        new_region.locations.append(location)
 
-  return new_region
+    return new_region
 
 
 # Creates connections based on our access mapping in `noita_connections`.
-def create_connections(player, regions):
-  for source, destinations in noita_connections.items():
-    new_entrances = []
+def create_connections(player: int, regions: Dict[str, Region]) -> None:
+    for source, destinations in noita_connections.items():
+        new_entrances = []
 
-    for destination in destinations:
-      # An "Entrance" is really just a connection between two regions
-      entrance = Entrance(player, f"From {source} To {destination}", regions[source])
-      entrance.connect(regions[destination])
-      new_entrances.append(entrance)
+        for destination in destinations:
+            # An "Entrance" is really just a connection between two regions
+            entrance = Entrance(player, f"From {source} To {destination}", regions[source])
+            entrance.connect(regions[destination])
+            new_entrances.append(entrance)
 
-    regions[source].exits = new_entrances
+        regions[source].exits = new_entrances
+
+
+def create_regions(world: MultiWorld, player: int) -> Dict[str, Region]:
+    return {name: create_region(world, player, name) for name in noita_regions}
 
 
 # Creates all regions and connections. Called from NoitaWorld.
-def create_all_regions(world, player: int):
-  created_regions = { name: create_region(world, player, name) for name in noita_regions }
-  create_connections(player, created_regions)
-  
-  world.regions += created_regions.values()
+def create_all_regions_and_connections(world: MultiWorld, player: int) -> None:
+    created_regions = create_regions(world, player)
+    create_connections(player, created_regions)
+
+    world.regions += created_regions.values()
 
 
+noita_connections: Dict[str, Set[str]] = {
+    "Menu": {"Forest"},
+    "Forest": {"Mines", "Collapsed Mines"},
 
-noita_regions = {
-  "Menu", "Forest",
-  
-  "Mines", "Collapsed Mines", "Lava Lake", "Dark Cave", "Shaft",
+    "Mines": {"Collapsed Mines", "Holy Mountain 1 (To Coal Pits)", "Lava Lake", "Forest"},
+    "Collapsed Mines": {"Mines", "Holy Mountain 1 (To Coal Pits)", "Dark Cave"},
+    "Lava Lake": {"Mines", "Shaft"},
+    "Shaft": {"Lava Lake", "Snowy Depths"},
 
-  "Coal Pits", "Fungal Caverns",
+    ###
+    "Holy Mountain 1 (To Coal Pits)": {"Coal Pits"},
+    "Coal Pits": {"Holy Mountain 1 (To Coal Pits)", "Fungal Caverns", "Holy Mountain 2 (To Snowy Depths)"},
+    "Fungal Caverns": {"Coal Pits"},
 
-  "Snowy Depths",
+    ###
+    "Holy Mountain 2 (To Snowy Depths)": {"Snowy Depths"},
+    "Snowy Depths": {"Shaft", "Holy Mountain 2 (To Snowy Depths)", "Holy Mountain 3 (To Hiisi Base)"},
 
-  "Hiisi Base", "Secret Shop",
+    ###
+    "Holy Mountain 3 (To Hiisi Base)": {"Hiisi Base"},
+    "Hiisi Base": {"Holy Mountain 3 (To Hiisi Base)", "Secret Shop", "Holy Mountain 4 (To Underground Jungle)"},
 
-  "Underground Jungle", "Dragoncave",
+    ###
+    "Holy Mountain 4 (To Underground Jungle)": {"Underground Jungle"},
+    "Dragoncave": {"Underground Jungle"},
+    "Underground Jungle": {"Holy Mountain 4 (To Underground Jungle)", "Dragoncave", "Holy Mountain 5 (To The Vault)"},
 
-  "The Vault",
+    ###
+    "Holy Mountain 5 (To The Vault)": {"The Vault"},
+    "The Vault": {"Holy Mountain 5 (To The Vault)", "Holy Mountain 6 (To Temple of the Art)"},
 
-  "Temple of the Art",
+    ###
+    "Holy Mountain 6 (To Temple of the Art)": {"Temple of the Art"},
+    "Temple of the Art": {"Holy Mountain 6 (To Temple of the Art)", "Holy Mountain 7 (To The Laboratory)"},
 
-  "The Laboratory", "The Work",
-
-  "Holy Mountain 1 (To Coal Pits)",
-  "Holy Mountain 2 (To Snowy Depths)",
-  "Holy Mountain 3 (To Hiisi Base)",
-  "Holy Mountain 4 (To Underground Jungle)",
-  "Holy Mountain 5 (To The Vault)",
-  "Holy Mountain 6 (To Temple of the Art)",
-  "Holy Mountain 7 (To The Laboratory)"
+    ###
+    "Holy Mountain 7 (To The Laboratory)": {"The Laboratory"},
+    "The Laboratory": {"Holy Mountain 7 (To The Laboratory)", "The Work"},
 }
 
-noita_connections: Dict[str, List[str]] = {
-  "Menu": ["Forest"],
-  "Forest": ["Mines", "Collapsed Mines"],
-
-  "Mines": ["Collapsed Mines", "Holy Mountain 1 (To Coal Pits)", "Lava Lake", "Forest"],
-  "Collapsed Mines": ["Mines", "Holy Mountain 1 (To Coal Pits)", "Dark Cave"],
-  "Lava Lake": ["Mines", "Shaft"],
-  "Shaft": ["Lava Lake", "Snowy Depths"],
-
-  ###
-  "Holy Mountain 1 (To Coal Pits)": ["Coal Pits"],
-  "Coal Pits": ["Holy Mountain 1 (To Coal Pits)", "Fungal Caverns", "Holy Mountain 2 (To Snowy Depths)"],
-  "Fungal Caverns": ["Coal Pits"],
-
-  ###
-  "Holy Mountain 2 (To Snowy Depths)": ["Snowy Depths"],
-  "Snowy Depths": ["Shaft", "Holy Mountain 2 (To Snowy Depths)", "Holy Mountain 3 (To Hiisi Base)"],
-  
-  ###
-  "Holy Mountain 3 (To Hiisi Base)": ["Hiisi Base"],
-  "Hiisi Base": ["Holy Mountain 3 (To Hiisi Base)", "Secret Shop", "Holy Mountain 4 (To Underground Jungle)"],
-
-  ###
-  "Holy Mountain 4 (To Underground Jungle)": ["Underground Jungle"],
-  "Dragoncave": ["Underground Jungle"],
-  "Underground Jungle": ["Holy Mountain 4 (To Underground Jungle)", "Dragoncave", "Holy Mountain 5 (To The Vault)"],
-  
-  ###
-  "Holy Mountain 5 (To The Vault)": ["The Vault"],
-  "The Vault": ["Holy Mountain 5 (To The Vault)", "Holy Mountain 6 (To Temple of the Art)"],
-  
-  ###
-  "Holy Mountain 6 (To Temple of the Art)": ["Temple of the Art"],
-  "Temple of the Art": ["Holy Mountain 6 (To Temple of the Art)", "Holy Mountain 7 (To The Laboratory)"],
-
-  ###
-  "Holy Mountain 7 (To The Laboratory)": ["The Laboratory"],
-  "The Laboratory": ["Holy Mountain 7 (To The Laboratory)", "The Work"],
-}
+noita_regions: Set[str] = set(noita_connections.keys()) + set.union(*noita_connections.values())

--- a/worlds/noita/Regions.py
+++ b/worlds/noita/Regions.py
@@ -1,7 +1,8 @@
 # Regions are areas in your game that you travel to.
 import itertools
-from Typing import Dict, List
-from BaseClasses import Region, Entrance, LocationProgressType
+from typing import Dict, List
+from BaseClasses import Region, Entrance, LocationProgressType, RegionType
+from . import Locations
 
 
 # Creates a new Region with the locations found in `location_region_mapping`
@@ -13,6 +14,7 @@ def create_region(world, player: int, region_name: str):
   for location_name, location_id in Locations.location_region_mapping.get(region_name, {}).items():
     location = Locations.NoitaLocation(player, location_name, location_id, new_region)
 
+    # TODO this is a hack.
     # If it's not the region with all the shitty chests, increases the priority of important items.
     # This way people know they can find their items by checking fixed locations instead of
     # leaving it up to chance.
@@ -21,7 +23,6 @@ def create_region(world, player: int, region_name: str):
 
     new_region.locations.append(location)
 
-  world.regions.append(new_region)
   return new_region
 
 
@@ -36,13 +37,16 @@ def create_connections(player, regions):
       entrance.connect(regions[destination])
       new_entrances.append(entrance)
 
-    created_regions[source].exits = new_entrances
+    regions[source].exits = new_entrances
 
 
 # Creates all regions and connections. Called from NoitaWorld.
 def create_all_regions(world, player: int):
   created_regions = { name: create_region(world, player, name) for name in noita_regions }
   create_connections(player, created_regions)
+  
+  world.regions += created_regions.values()
+
 
 
 noita_regions = {
@@ -69,6 +73,8 @@ noita_regions = {
   "Holy Mountain 3 (To Hiisi Base)",
   "Holy Mountain 4 (To Underground Jungle)",
   "Holy Mountain 5 (To The Vault)",
+  "Holy Mountain 6 (To Temple of the Art)",
+  "Holy Mountain 7 (To The Laboratory)"
 }
 
 noita_connections: Dict[str, List[str]] = {

--- a/worlds/noita/Rules.py
+++ b/worlds/noita/Rules.py
@@ -1,0 +1,6 @@
+
+
+
+def create_all_rules(world, player: int) -> None:
+  "" #TODO
+

--- a/worlds/noita/Rules.py
+++ b/worlds/noita/Rules.py
@@ -1,6 +1,5 @@
+from BaseClasses import MultiWorld
 
 
-
-def create_all_rules(world, player: int) -> None:
-  "" #TODO
-
+def create_all_rules(world: MultiWorld, player: int) -> None:
+    ""  # TODO

--- a/worlds/noita/__init__.py
+++ b/worlds/noita/__init__.py
@@ -1,13 +1,13 @@
-import functools
 import string
 
-from BaseClasses import Tutorial, ItemClassification, Item, MultiWorld
+from BaseClasses import Tutorial
 from worlds.AutoWorld import World, WebWorld
 
-from . import Options, Items, Locations, Regions, Rules
+from . import Options, Items, Locations, Regions, Rules, Events
 
 # TODO: Ban higher tier wands from appearing in earlier locations
-# TODO: Reaching a holy mountain unlocks the holy mountain, gate it behind an event
+# TODO: Gate holy mountain access behind an event that triggers when you visit the same holy mountain?
+
 
 class NoitaWeb(WebWorld):
     tutorials = [Tutorial(
@@ -33,68 +33,30 @@ class NoitaWorld(World):
 
     item_name_to_id = Items.item_name_to_id
     location_name_to_id = Locations.location_name_to_id
-    
+
     item_name_groups = Items.item_name_groups
 
     data_version = 1
     forced_auto_forfeit = False
     web = NoitaWeb()
 
-
     def create_regions(self) -> None:
-        Regions.create_all_regions(self.world, self.player)
-
+        Regions.create_all_regions_and_connections(self.world, self.player)
 
     def create_items(self) -> None:
         Items.create_all_items(self.world, self.player)
 
-
     def set_rules(self) -> None:
-        "" #TODO
-
+        Rules.create_all_rules(self.world, self.player)
 
     # Generate victory conditions and other shenanigans
     def generate_basic(self) -> None:
-        # Generate Victory shenanigans (TODO this is temporary)
-        the_work_region = self.world.get_region("The Work", self.player)
-        victory_loc = Locations.NoitaLocation(self.player, "Victory", None, the_work_region)
-
-        victory_loc.place_locked_item(self.create_event("Victory"))
-        self.world.completion_condition[self.player] = lambda state: state.has("Victory", self.player)
-
-        the_work_region.locations.append(victory_loc)
-
-        # Create events
-        self.create_events()
-
+        Events.create_all_events(self.world, self.player)
 
     def get_filler_item_name(self) -> str:
         return self.world.random.choice(Items.filler_items)
 
-
-    # TODO Should we move events out to keep this slim?
-    def create_event(self, name: str) -> Item:
-        return Items.NoitaItem(name, ItemClassification.progression, None, self.player)
-
-
-    # TODO Should we move events out to keep this slim?
-    def create_events(self) -> None:
-        total_locations = self.world.total_locations[self.player].value
-
-        # TODO This is a hack for now, we throw all the chest popups in Forest
-        forest_region = self.world.get_region("Forest", self.player)
-
-        # Iterates all our generated chests and makes sure that they are accessible in a specific
-        # logical order (?) TODO: Revisit and confirm this
-        for i in range(1, 1 + total_locations):
-            pickup_event = self.create_event(f"Pickup{(i + 1)}")
-
-            event_loc = Locations.NoitaLocation(self.player, pickup_event.name, None, forest_region)
-            event_loc.place_locked_item(pickup_event)
-            event_loc.access_rule(lambda state, i=i: state.can_reach(f"Chest{i}", "Location", self.player))
-            forest_region.locations.append(event_loc)
-
-
+    # Things here will be sent to the client.
     def fill_slot_data(self):
         return {
             "seed": "".join(self.world.slot_seeds[self.player].choices(string.digits, k=16)),

--- a/worlds/noita/__init__.py
+++ b/worlds/noita/__init__.py
@@ -1,11 +1,13 @@
 import functools
 import string
 
-from BaseClasses import Tutorial, ItemClassification, Item
+from BaseClasses import Tutorial, ItemClassification, Item, MultiWorld
 from worlds.AutoWorld import World, WebWorld
 
-client_version = 1 # TODO: Do we need this random variable??
+from . import Options, Items, Locations, Regions, Rules
 
+# TODO: Ban higher tier wands from appearing in earlier locations
+# TODO: Reaching a holy mountain unlocks the holy mountain, gate it behind an event
 
 class NoitaWeb(WebWorld):
     tutorials = [Tutorial(
@@ -53,31 +55,49 @@ class NoitaWorld(World):
 
     # Generate victory conditions and other shenanigans
     def generate_basic(self) -> None:
-        self.world.get_location("The Work", self.player).place_locked_item(self.create_event("Victory"))
-        self.completion_condition[self.player] = lambda state: state.has("Victory")
+        # Generate Victory shenanigans (TODO this is temporary)
+        the_work_region = self.world.get_region("The Work", self.player)
+        victory_loc = Locations.NoitaLocation(self.player, "Victory", None, the_work_region)
+
+        victory_loc.place_locked_item(self.create_event("Victory"))
+        self.world.completion_condition[self.player] = lambda state: state.has("Victory", self.player)
+
+        the_work_region.locations.append(victory_loc)
+
+        # Create events
+        self.create_events()
 
 
     def get_filler_item_name(self) -> str:
         return self.world.random.choice(Items.filler_items)
 
 
+    # TODO Should we move events out to keep this slim?
     def create_event(self, name: str) -> Item:
         return Items.NoitaItem(name, ItemClassification.progression, None, self.player)
 
 
-    #def create_events(world: MultiWorld, player: int) -> None:
-    #    total_locations = world.total_locations[player].value
-    #    world_region = world.get_region("Mines", player)
-    #    for i in range(1, 1 + total_locations):
-    #        event_loc = NoitaLocation(player, f"Pickup{(i + 1)}", None, world_region)
-    #        event_loc.place_locked_item(NoitaItem(f"Pickup{(i + 1)}", ItemClassification.progression, None, player))
-    #        event_loc.access_rule(lambda state, i=i: state.can_reach(f"Chest{(i + 1) - 1}", player))
-    #        world_region.locations.append(event_loc)
+    # TODO Should we move events out to keep this slim?
+    def create_events(self) -> None:
+        total_locations = self.world.total_locations[self.player].value
+
+        # TODO This is a hack for now, we throw all the chest popups in Forest
+        forest_region = self.world.get_region("Forest", self.player)
+
+        # Iterates all our generated chests and makes sure that they are accessible in a specific
+        # logical order (?) TODO: Revisit and confirm this
+        for i in range(1, 1 + total_locations):
+            pickup_event = self.create_event(f"Pickup{(i + 1)}")
+
+            event_loc = Locations.NoitaLocation(self.player, pickup_event.name, None, forest_region)
+            event_loc.place_locked_item(pickup_event)
+            event_loc.access_rule(lambda state, i=i: state.can_reach(f"Chest{i}", "Location", self.player))
+            forest_region.locations.append(event_loc)
 
 
     def fill_slot_data(self):
         return {
-            "seed": "".join(self.world.slot_seeds[self.player].choice(string.digits) for i in range(16)),
+            "seed": "".join(self.world.slot_seeds[self.player].choices(string.digits, k=16)),
             "totalLocations": self.world.total_locations[self.player].value,
             "badEffects": self.world.bad_effects[self.player].value,
             "deathLink": self.world.death_link[self.player].value,

--- a/worlds/noita/__init__.py
+++ b/worlds/noita/__init__.py
@@ -37,7 +37,6 @@ class NoitaWorld(World):
     item_name_groups = Items.item_name_groups
 
     data_version = 1
-    forced_auto_forfeit = False
     web = NoitaWeb()
 
     def create_regions(self) -> None:


### PR DESCRIPTION
1. Complete rewrite not based on any other AP implementation. Everything moved out of __init__.py, should help with clarity.
2. Follows the style guide.
3. Added regions and connections for a few of the game's main areas.
4. Added item groups which happens to be another AP feature.
5. Added Victory event (currently not triggered).
6. Added shop item locations.
7. Implement get_filler_item_name for filler items.
8. Prioritise progression items in shops rather than chests.

Things that still need to be done that won't be part of this PR: Add events between Holy Mountains to solidify progression more. Ban higher tier wands from appearing in earlier locations in Noita.