### PR TITLE
Send slot options universally without redefining options

### DIFF
--- a/worlds/noita/__init__.py
+++ b/worlds/noita/__init__.py
@@ -48,8 +48,8 @@ class NoitaWorld(World):
             "seed": self.world.seed_name,
         }
 
-        for option_name in option_definitions:
-            slot_data[option_name] = get_option(option_name)
+        for option_name in self.option_definitions:
+            slot_data[option_name] = self.get_option(option_name)
 
         return slot_data
 

--- a/worlds/noita/__init__.py
+++ b/worlds/noita/__init__.py
@@ -40,16 +40,18 @@ class NoitaWorld(World):
     data_version = 1
     web = NoitaWeb()
 
+    def get_option(self, name):
+        return getattr(self.world, name)[self.player].value
+
     def fill_slot_data(self):
-        return {
-            "seed": "".join(self.world.slot_seeds[self.player].choices(string.digits, k=16)),
-            "totalLocations": self.world.total_locations[self.player].value,
-            "badEffects": self.world.bad_effects[self.player].value,
-            "deathLink": self.world.death_link[self.player].value,
-            "victoryCondition": self.world.victory_condition[self.player].value,
-            "orbsAsChecks": self.world.orbs_as_checks[self.player].value,
-            "bossesAsChecks": self.world.bosses_as_checks[self.player].value,
+        slot_data = {
+            "seed": self.world.seed_name,
         }
+
+        for option_name in option_definitions:
+            slot_data[option_name] = get_option(option_name)
+
+        return slot_data
 
     def create_regions(self) -> None:
         Regions.create_all_regions_and_connections(self.world, self.player)


### PR DESCRIPTION
This allows any new options to be sent automatically without having to also redefine it here too.