### PR TITLE
Add 11 new locations (secret shop, spell refreshers)

### DIFF
--- a/worlds/noita/Items.py
+++ b/worlds/noita/Items.py
@@ -23,52 +23,32 @@ def create_item(player: int, name: str) -> Item:
 def create_all_items(world: MultiWorld, player: int) -> None:
     pool_option = world.bad_effects[player].value
     total_locations = world.total_locations[player].value
-    # Generate fixed item pool
+
+    # Generate fixed item pool, these are items with a specific fixed quantity that must be added
     itempool: List = []
     for item_name, count in required_items.items():
         itempool += [item_name] * count
 
+    # Generate items based on victory condition settings (Orbs)
     vic = world.victory_condition[player].value
     orb_count = 0
     if vic == 1: orb_count = 11
     if vic == 2: orb_count = 33
     for i in range(orb_count):
         itempool += ["Orb"]
+
     # todo: put a rule in that says this perk can't be placed at Toveri
     if world.bosses_as_checks[player].value >= 2:
         itempool += ["Perk (Spatial Awareness)"]
 
-    # Add non-fixed items to the pool to meet quota
-    static_locations = 0
-
-    # todo: find a better way to do the below, or put it in a separate place
-    if world.bosses_as_checks[player].value >= 1:
-        static_locations += Locations.boss_mp_locations
-    if world.bosses_as_checks[player].value >= 2:
-        static_locations += Locations.boss_mw_locations
-    if world.orbs_as_checks[player].value >= 1:
-        static_locations += Locations.orb_mp_locations
-    if world.orbs_as_checks[player].value >= 2:
-        static_locations += Locations.orb_mw_locations
-    static_locations += Locations.shop_locations
-
-    useful_pool = useful_weights
+    # Create any non-progression repeat items (referred to as junk regardless of whether it's useful)
     junk_pool = item_pool_weights[pool_option]
-
     random_count = total_locations - len(itempool)
-    junk_count = total_locations - static_locations
-    useful_count = random_count - junk_count
-
-    itempool += world.random.choices(
-        population=list(useful_pool.keys()),
-        weights=list(useful_pool.values()),
-        k=useful_count
-    )
 
     itempool += world.random.choices(
         population=list(junk_pool.keys()),
         weights=list(junk_pool.values()),
-        k=junk_count
+        k=random_count
     )
 
     # Convert itempool into real items
@@ -114,19 +94,19 @@ item_table: Dict[str, ItemData] = {
 
 # todo: test rates, make sure it's fun
 default_weights: Dict[str, int] = {
-    # "Wand (Tier 1)":    10,
+    "Wand (Tier 1)":    10,
     "Potion":           35,
     "Refresh":          25,
-    # "Heart":            25,
-    # "Wand (Tier 2)":    9,
-    # "Wand (Tier 3)":    8,
+    "Heart":            25,
+    "Wand (Tier 2)":    9,
+    "Wand (Tier 3)":    8,
     "Bad":              15,
     "Gold (200)":       15,
-    # "Wand (Tier 4)":    7,
-    # "Wand (Tier 5)":    6,
+    "Wand (Tier 4)":    7,
+    "Wand (Tier 5)":    6,
     "Gold (1000)":      5,
-    # "Wand (Tier 6)":    4,
-    # "Perk (Extra Life)": 4,
+    "Wand (Tier 6)":    4,
+    "Perk (Extra Life)": 4,
     "Random Potion":    5,
     "Secret Potion":    5,
     "Chaos Die":        5,
@@ -139,19 +119,19 @@ default_weights: Dict[str, int] = {
 }
 
 no_bad_weights: Dict[str, int] = {
-    # "Wand (Tier 1)":    10,
+    "Wand (Tier 1)":    10,
     "Potion":           35,
     "Refresh":          25,
-    # "Heart":            25,
-    # "Wand (Tier 2)":    9,
-    # "Wand (Tier 3)":    8,
+    "Heart":            25,
+    "Wand (Tier 2)":    9,
+    "Wand (Tier 3)":    8,
     "Bad":              0,
     "Gold (200)":       15,
-    # "Wand (Tier 4)":    7,
-    # "Wand (Tier 5)":    6,
+    "Wand (Tier 4)":    7,
+    "Wand (Tier 5)":    6,
     "Gold (1000)":      5,
-    # "Wand (Tier 6)":    4,
-    # "Perk (Extra Life)": 4,
+    "Wand (Tier 6)":    4,
+    "Perk (Extra Life)": 4,
     "Random Potion":    5,
     "Secret Potion":    5,
     "Chaos Die":        5,
@@ -161,18 +141,6 @@ no_bad_weights: Dict[str, int] = {
     "Sadekivi":         5,
     "Broken Wand":      10,
     "Powder Pouch":     10,
-}
-
-# potentially separating useful and filler items into their own tables
-useful_weights: Dict[str, int] = {
-    "Wand (Tier 1)": 10,
-    "Heart": 25,
-    "Wand (Tier 2)": 9,
-    "Wand (Tier 3)": 8,
-    "Wand (Tier 4)": 7,
-    "Wand (Tier 5)": 6,
-    "Wand (Tier 6)": 4,
-    "Perk (Extra Life)": 4,
 }
 
 item_pool_weights: Dict[int, Dict[str, int]] = {

--- a/worlds/noita/Locations.py
+++ b/worlds/noita/Locations.py
@@ -45,6 +45,7 @@ location_region_mapping: Dict[str, Dict[str, LocationData]] = {
         "Holy Mountain 1 (To Coal Pits) Shop Item 3": LocationData(111002),
         "Holy Mountain 1 (To Coal Pits) Shop Item 4": LocationData(111003),
         "Holy Mountain 1 (To Coal Pits) Shop Item 5": LocationData(111004),
+        "Holy Mountain 1 (To Coal Pits) Spell Refresh": LocationData(111035),
     },
     "Holy Mountain 2 (To Snowy Depths)": {
         "Holy Mountain 2 (To Snowy Depths) Shop Item 1": LocationData(111005),
@@ -52,6 +53,7 @@ location_region_mapping: Dict[str, Dict[str, LocationData]] = {
         "Holy Mountain 2 (To Snowy Depths) Shop Item 3": LocationData(111007),
         "Holy Mountain 2 (To Snowy Depths) Shop Item 4": LocationData(111008),
         "Holy Mountain 2 (To Snowy Depths) Shop Item 5": LocationData(111009),
+        "Holy Mountain 2 (To Snowy Depths) Spell Refresh": LocationData(111036),
     },
     "Holy Mountain 3 (To Hiisi Base)": {
         "Holy Mountain 3 (To Hiisi Base) Shop Item 1": LocationData(111010),
@@ -59,6 +61,7 @@ location_region_mapping: Dict[str, Dict[str, LocationData]] = {
         "Holy Mountain 3 (To Hiisi Base) Shop Item 3": LocationData(111012),
         "Holy Mountain 3 (To Hiisi Base) Shop Item 4": LocationData(111013),
         "Holy Mountain 3 (To Hiisi Base) Shop Item 5": LocationData(111014),
+        "Holy Mountain 3 (To Hiisi Base) Spell Refresh": LocationData(111037),
     },
     "Holy Mountain 4 (To Underground Jungle)": {
         "Holy Mountain 4 (To Underground Jungle) Shop Item 1": LocationData(111015),
@@ -66,6 +69,7 @@ location_region_mapping: Dict[str, Dict[str, LocationData]] = {
         "Holy Mountain 4 (To Underground Jungle) Shop Item 3": LocationData(111017),
         "Holy Mountain 4 (To Underground Jungle) Shop Item 4": LocationData(111018),
         "Holy Mountain 4 (To Underground Jungle) Shop Item 5": LocationData(111019),
+        "Holy Mountain 4 (To Underground Jungle) Spell Refresh": LocationData(111038),
     },
     "Holy Mountain 5 (To The Vault)": {
         "Holy Mountain 5 (To The Vault) Shop Item 1": LocationData(111020),
@@ -73,6 +77,7 @@ location_region_mapping: Dict[str, Dict[str, LocationData]] = {
         "Holy Mountain 5 (To The Vault) Shop Item 3": LocationData(111022),
         "Holy Mountain 5 (To The Vault) Shop Item 4": LocationData(111023),
         "Holy Mountain 5 (To The Vault) Shop Item 5": LocationData(111024),
+        "Holy Mountain 5 (To The Vault) Spell Refresh": LocationData(111039),
     },
     "Holy Mountain 6 (To Temple of the Art)": {
         "Holy Mountain 6 (To Temple of the Art) Shop Item 1": LocationData(111025),
@@ -80,6 +85,7 @@ location_region_mapping: Dict[str, Dict[str, LocationData]] = {
         "Holy Mountain 6 (To Temple of the Art) Shop Item 3": LocationData(111027),
         "Holy Mountain 6 (To Temple of the Art) Shop Item 4": LocationData(111028),
         "Holy Mountain 6 (To Temple of the Art) Shop Item 5": LocationData(111029),
+        "Holy Mountain 6 (To Temple of the Art) Spell Refresh": LocationData(111040),
     },
     "Holy Mountain 7 (To The Laboratory)": {
         "Holy Mountain 7 (To The Laboratory) Shop Item 1": LocationData(111030),
@@ -87,6 +93,13 @@ location_region_mapping: Dict[str, Dict[str, LocationData]] = {
         "Holy Mountain 7 (To The Laboratory) Shop Item 3": LocationData(111032),
         "Holy Mountain 7 (To The Laboratory) Shop Item 4": LocationData(111033),
         "Holy Mountain 7 (To The Laboratory) Shop Item 5": LocationData(111034),
+        "Holy Mountain 7 (To The Laboratory) Spell Refresh": LocationData(111041),
+    },
+    "Secret Shop": {
+        "Secret Shop Item 1": LocationData(111042),
+        "Secret Shop Item 2": LocationData(111043),
+        "Secret Shop Item 3": LocationData(111044),
+        "Secret Shop Item 4": LocationData(111045),
     },
     "Floating Island": {
         "Floating Island Orb": LocationData(110501, "orb", Orbs.main_path),

--- a/worlds/noita/Rules.py
+++ b/worlds/noita/Rules.py
@@ -16,12 +16,12 @@ holy_mountain_regions: List[str] = [
 ]
 
 wand_tiers: List[str] = [
-    "Wand (Tier 1)",
-    "Wand (Tier 2)",
-    "Wand (Tier 3)",
-    "Wand (Tier 4)",
-    "Wand (Tier 5)",
-    "Wand (Tier 6)",
+    "Wand (Tier 1)",    # Coal Pits
+    "Wand (Tier 2)",    # Snowy Depths
+    "Wand (Tier 3)",    # Hiisi Base
+    "Wand (Tier 4)",    # Underground Jungle
+    "Wand (Tier 5)",    # The Vault
+    "Wand (Tier 6)",    # Temple of the Art
 ]
 
 items_hidden_from_shops: Set[str] = {"Gold (10)", "Gold (50)", "Gold (200)", "Gold (1000)", "Potion", "Random Potion",
@@ -48,6 +48,13 @@ def create_all_rules(world: MultiWorld, player: int) -> None:
         locations_in_region = Locations.location_region_mapping[region_name].keys()
         for location_name in locations_in_region:
             forbid_items_at_location(world, location_name, wands_to_forbid, player)
+
+    # Prevent high tier wands from appearing in the Secret shop
+    wands_to_forbid = wand_tiers[3:]
+    locations_in_region = Locations.location_region_mapping["Secret Shop"].keys()
+    for location_name in locations_in_region:
+        forbid_items_at_location(world, location_name, wands_to_forbid, player)
+
     #
     # # Prevent the Map perk from being on Toveri
     # for location_name in Locations.location_name_to_id.keys():

--- a/worlds/noita/__init__.py
+++ b/worlds/noita/__init__.py
@@ -48,8 +48,8 @@ class NoitaWorld(World):
             "seed": self.world.seed_name,
         }
 
-        for option_name in option_definitions:
-            slot_data[option_name] = get_option(option_name)
+        for option_name in self.option_definitions:
+            slot_data[option_name] = self.get_option(option_name)
 
         return slot_data
 

--- a/worlds/noita/__init__.py
+++ b/worlds/noita/__init__.py
@@ -40,16 +40,18 @@ class NoitaWorld(World):
     data_version = 1
     web = NoitaWeb()
 
+    def get_option(self, name):
+        return getattr(self.world, name)[self.player].value
+
     def fill_slot_data(self):
-        return {
-            "seed": "".join(self.world.slot_seeds[self.player].choices(string.digits, k=16)),
-            "totalLocations": self.world.total_locations[self.player].value,
-            "badEffects": self.world.bad_effects[self.player].value,
-            "deathLink": self.world.death_link[self.player].value,
-            "victoryCondition": self.world.victory_condition[self.player].value,
-            "orbsAsChecks": self.world.orbs_as_checks[self.player].value,
-            "bossesAsChecks": self.world.bosses_as_checks[self.player].value,
+        slot_data = {
+            "seed": self.world.seed_name,
         }
+
+        for option_name in option_definitions:
+            slot_data[option_name] = get_option(option_name)
+
+        return slot_data
 
     def create_regions(self) -> None:
         Regions.create_all_regions_and_connections(self.world, self.player)

--- a/worlds/noita/__init__.py
+++ b/worlds/noita/__init__.py
@@ -6,7 +6,6 @@ from worlds.AutoWorld import World, WebWorld
 from . import Options, Items, Locations, Regions, Rules, Events
 from .Options import noita_options
 
-# TODO: Ban higher tier wands from appearing in earlier locations
 # TODO: Gate holy mountain access behind an event that triggers when you visit the same holy mountain?
 
 


### PR DESCRIPTION
- Undo the split of useful "junk" items
- Make it easier not to mess up locations by generating chests after all other locations are generated.
- Fixes the item to location quantity mismatch

Depends on https://github.com/DaftBrit/Archipelago/pull/11