### PR TITLE
Fixes to init so that Noita passes the unit tests

### DIFF
--- a/worlds/noita/__init__.py
+++ b/worlds/noita/__init__.py
@@ -56,9 +56,7 @@ class NoitaWorld(World):
         Events.create_all_events(self.multiworld, self.player)
     
     def create_item(self, name: str) -> Item:
-        Items.create_item(self.player, name)
-        item_data = item_table[name]
-        return NoitaItem(name, item_data.classification, item_data.code, self.player)
+        return Items.create_item(self.player, name)
         
     def create_items(self) -> None:
         Items.create_all_items(self.multiworld, self.player)

--- a/worlds/noita/__init__.py
+++ b/worlds/noita/__init__.py
@@ -58,7 +58,7 @@ class NoitaWorld(World):
     def create_item(self, name: str) -> Item:
         Items.create_item(self.player, name)
         item_data = item_table[name]
-        return NoitaItem(name, item_data.classification, item_data.code, player)
+        return NoitaItem(name, item_data.classification, item_data.code, self.player)
         
     def create_items(self) -> None:
         Items.create_all_items(self.multiworld, self.player)

--- a/worlds/noita/__init__.py
+++ b/worlds/noita/__init__.py
@@ -1,7 +1,8 @@
-from BaseClasses import Tutorial
+from BaseClasses import Tutorial, Item
 from worlds.AutoWorld import World, WebWorld
 from . import Options, Items, Locations, Regions, Rules, Events
 from .Options import noita_options
+from .Items import NoitaItem, item_table
 
 
 class NoitaWeb(WebWorld):
@@ -27,6 +28,7 @@ class NoitaWorld(World):
     game = "Noita"
     option_definitions = Options.noita_options
     topology_present = True
+    data_version = 0
 
     item_name_to_id = Items.item_name_to_id
     location_name_to_id = Locations.location_name_to_id
@@ -51,16 +53,18 @@ class NoitaWorld(World):
 
     def create_regions(self) -> None:
         Regions.create_all_regions_and_connections(self.multiworld, self.player)
-
+        Events.create_all_events(self.multiworld, self.player)
+    
+    def create_item(self, name: str) -> Item:
+        Items.create_item(self.player, name)
+        item_data = item_table[name]
+        return NoitaItem(name, item_data.classification, item_data.code, player)
+        
     def create_items(self) -> None:
         Items.create_all_items(self.multiworld, self.player)
 
     def set_rules(self) -> None:
-        Rules.create_all_rules(self.multiworld, self.player)
-
-    # Generate victory conditions and other shenanigans
-    def generate_basic(self) -> None:
-        Events.create_all_events(self.multiworld, self.player)
+        Rules.create_all_rules(self.multiworld, self.player)      
 
     def get_filler_item_name(self) -> str:
         return self.multiworld.random.choice(Items.filler_items)

--- a/worlds/noita/__init__.py
+++ b/worlds/noita/__init__.py
@@ -2,7 +2,6 @@ from BaseClasses import Tutorial, Item
 from worlds.AutoWorld import World, WebWorld
 from . import Options, Items, Locations, Regions, Rules, Events
 from .Options import noita_options
-from .Items import NoitaItem, item_table
 
 
 class NoitaWeb(WebWorld):


### PR DESCRIPTION
create_item must be defined in init or the tests will fail. Locations cannot be modified during generate_basic or the tests will fail. They are also actively cracking down on other games doing this (there's a thread up in the ap dev channel). We just plain don't need generate_basic so I've straight up deleted it.

With this set up, it succeeds in generating with other worlds that have been tested with, particularly that cluster of worlds that Witchy had yesterday.