### PR TITLE
Unlock conditions for the holy mountains.

### DIFF
--- a/worlds/noita/Items.py
+++ b/worlds/noita/Items.py
@@ -98,7 +98,7 @@ filler_weights: Dict[str, int] = {
     "Trap":             15,
     "Extra Max HP":     25,
     "Spell Refresher":  20,
-    "Potion":           45,
+    "Potion":           40,
     "Gold (200)":       15,
     "Gold (1000)":      6,
     "Wand (Tier 1)":    10,
@@ -108,8 +108,8 @@ filler_weights: Dict[str, int] = {
     "Wand (Tier 5)":    5,
     "Wand (Tier 6)":    4,
     "Perk (Extra Life)": 10,
-    "Random Potion":    7,
-    "Secret Potion":    7,
+    "Random Potion":    9,
+    "Secret Potion":    10,
     "Chaos Die":        4,
     "Greed Die":        4,
     "Kammi":            4,
@@ -127,6 +127,10 @@ def get_item_group(item_name: str) -> str:
 
 def item_is_filler(item_name: str) -> bool:
     return item_table[item_name].classification == ItemClassification.filler
+
+
+def item_is_perk(item_name: str) -> bool:
+    return item_table[item_name].group == "Perks"
 
 
 filler_items: List[str] = list(filter(item_is_filler, item_table.keys()))

--- a/worlds/noita/Regions.py
+++ b/worlds/noita/Regions.py
@@ -74,6 +74,7 @@ def create_all_regions_and_connections(world: MultiWorld, player: int) -> None:
 # - Shaft is excluded to disconnect Mines from the Snowy Depths
 # - Lukki Lair is disconnected from The Vault
 # - Overgrown Cavern is disconnected from the Desert
+# - Snow Chasm is disconnected from the Snowy Wastelands
 noita_connections: Dict[str, Set[str]] = {
     "Menu": {"Forest"},
     "Forest": {"Mines", "Floating Island", "Desert", "Snowy Wasteland"},

--- a/worlds/noita/Regions.py
+++ b/worlds/noita/Regions.py
@@ -128,7 +128,7 @@ noita_connections: Dict[str, Set[str]] = {
     "Temple of the Art": {"Holy Mountain 6 (To Temple of the Art)", "Holy Mountain 7 (To The Laboratory)", "The Tower",
                           "Wizard's Den"},
     "Wizard's Den": {"Temple of the Art", "Powerplant"},
-    "Powerplant": {"Wizard's Den", "Deep Underground"},
+    "Powerplant": {"Wizard's Den", "Deep Underground", "Sandcave"},
     "The Tower": {"Forest"},
     "Deep Underground": {},
 

--- a/worlds/noita/Rules.py
+++ b/worlds/noita/Rules.py
@@ -60,20 +60,12 @@ def get_orb_count(state: CollectionState, player: int) -> int:
     return state.item_count("Orb", player)
 
 
-def get_heart_count(state: CollectionState, player: int) -> int:
-    return state.item_count("Extra Max HP", player)
-
-
 def has_perk_count(state: CollectionState, player: int, amount: int) -> bool:
     return get_perk_count(state, player) >= amount
 
 
 def has_orb_count(state: CollectionState, player: int, amount: int) -> bool:
     return get_orb_count(state, player) >= amount
-
-
-def has_heart_count(state: CollectionState, player: int, amount: int) -> bool:
-    return get_heart_count(state, player) >= amount
 
 
 def forbid_items_at_location(world: MultiWorld, location_name: str, items: Set[str], player: int):

--- a/worlds/noita/Rules.py
+++ b/worlds/noita/Rules.py
@@ -1,8 +1,8 @@
-from BaseClasses import MultiWorld
+from BaseClasses import MultiWorld, CollectionState
 from typing import List, NamedTuple, Set
 
 from ..generic import Rules as GenericRules
-from . import Locations, Options
+from . import Locations, Options, Items
 
 
 holy_mountain_regions: List[str] = [
@@ -20,17 +20,18 @@ class EntranceLock(NamedTuple):
     source: str
     destination: str
     event: str
+    items_needed: int
 
 
-entrance_locks: List[EntranceLock] = {
-    EntranceLock("Mines", "Holy Mountain 1 (To Coal Pits)", "Portal to Holy Mountain 1"),
-    EntranceLock("Coal Pits", "Holy Mountain 2 (To Snowy Depths)", "Portal to Holy Mountain 2"),
-    EntranceLock("Snowy Depths", "Holy Mountain 3 (To Hiisi Base)", "Portal to Holy Mountain 3"),
-    EntranceLock("Hiisi Base", "Holy Mountain 4 (To Underground Jungle)", "Portal to Holy Mountain 4"),
-    EntranceLock("Underground Jungle", "Holy Mountain 5 (To The Vault)", "Portal to Holy Mountain 5"),
-    EntranceLock("The Vault", "Holy Mountain 6 (To Temple of the Art)", "Portal to Holy Mountain 6"),
-    EntranceLock("Temple of the Art", "Holy Mountain 7 (To The Laboratory)", "Portal to Holy Mountain 7"),
-}
+entrance_locks: List[EntranceLock] = [
+    EntranceLock("Mines", "Holy Mountain 1 (To Coal Pits)", "Portal to Holy Mountain 1", 1),
+    EntranceLock("Coal Pits", "Holy Mountain 2 (To Snowy Depths)", "Portal to Holy Mountain 2", 2),
+    EntranceLock("Snowy Depths", "Holy Mountain 3 (To Hiisi Base)", "Portal to Holy Mountain 3", 3),
+    EntranceLock("Hiisi Base", "Holy Mountain 4 (To Underground Jungle)", "Portal to Holy Mountain 4", 4),
+    EntranceLock("Underground Jungle", "Holy Mountain 5 (To The Vault)", "Portal to Holy Mountain 5", 5),
+    EntranceLock("The Vault", "Holy Mountain 6 (To Temple of the Art)", "Portal to Holy Mountain 6", 6),
+    EntranceLock("Temple of the Art", "Holy Mountain 7 (To The Laboratory)", "Portal to Holy Mountain 7", 7),
+]
 
 
 wand_tiers: List[str] = [
@@ -45,6 +46,34 @@ wand_tiers: List[str] = [
 items_hidden_from_shops: Set[str] = {"Gold (200)", "Gold (1000)", "Potion", "Random Potion", "Secret Potion",
                                      "Chaos Die", "Greed Die", "Kammi", "Refreshing Gourd", "Sädekivi", "Broken Wand",
                                      "Powder Pouch"}
+
+
+def get_perk_count(state: CollectionState, player: int) -> int:
+    perk_list: List[str] = list(filter(Items.item_is_perk, Items.item_table.keys()))
+    perk_count = 0
+    for perk in perk_list:
+        perk_count = perk_count + state.item_count(perk, player)
+    return perk_count
+
+
+def get_orb_count(state: CollectionState, player: int) -> int:
+    return state.item_count("Orb", player)
+
+
+def get_heart_count(state: CollectionState, player: int) -> int:
+    return state.item_count("Extra Max HP", player)
+
+
+def has_perk_count(state: CollectionState, player: int, amount: int) -> bool:
+    return get_perk_count(state, player) >= amount
+
+
+def has_orb_count(state: CollectionState, player: int, amount: int) -> bool:
+    return get_orb_count(state, player) >= amount
+
+
+def has_heart_count(state: CollectionState, player: int, amount: int) -> bool:
+    return get_heart_count(state, player) >= amount
 
 
 def forbid_items_at_location(world: MultiWorld, location_name: str, items: Set[str], player: int):
@@ -82,10 +111,29 @@ def lock_holy_mountains_into_spheres(world: MultiWorld, player: int) -> None:
         GenericRules.set_rule(location, lambda state, evt=lock.event: state.has(evt, player))
 
 
+def holy_mountain_unlock_conditions(world: MultiWorld, player: int) -> None:
+    vic = world.victory_condition[player].value
+    for lock in entrance_locks:
+        if vic == Options.VictoryCondition.option_greed_ending:
+            world.get_location(lock.event, player).access_rule = \
+                lambda state, items_needed=lock.items_needed: has_perk_count(state, player, items_needed//2)
+
+        elif vic == Options.VictoryCondition.option_pure_ending:
+            world.get_location(lock.event, player).access_rule = \
+                lambda state, items_needed=lock.items_needed: has_perk_count(state, player, items_needed) \
+                and has_orb_count(state, player, items_needed)
+
+        elif vic == Options.VictoryCondition.option_peaceful_ending:
+            world.get_location(lock.event, player).access_rule = \
+                lambda state, items_needed=lock.items_needed: has_perk_count(state, player, items_needed) \
+                and has_orb_count(state, player, items_needed * 3)
+
+
 def create_all_rules(world: MultiWorld, player: int) -> None:
     ban_items_from_shops(world, player)
     ban_early_high_tier_wands(world, player)
     lock_holy_mountains_into_spheres(world, player)
+    holy_mountain_unlock_conditions(world, player)
 
     # Prevent the Map perk (used to find Toveri) from being on Toveri (boss)
     if world.bosses_as_checks[player].value >= Options.BossesAsChecks.option_all_bosses:


### PR DESCRIPTION
Added in perk counts and orb counts (for applicable goals) as gates for the holy mountain portal events.
For the greed ending, one perk for every 2 holy mountains.
For pure, one perk and one orb per holy mountain.
For peaceful, one perk and three orbs per holy mountain.

Hearts were not included as originally planned, because I believe we would have to set them as progression items, and they're just overcomplicating things imo